### PR TITLE
Enable passing mock data to unit tests (Fixes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@ To run unit tests:
 ```
 npm test
 ```
+
+## Redirector configuration
+
+To configure a redirect, add an object to the `experimentPages` array in `workers/redirector.js`:
+
+```javascript
+const experimentPages = [
+    {
+        'targetPath': `/en-US/firefox/new/`,
+        'sandboxPath': `/en-US/exp/firefox/new/`,
+        'sampleRate': 0.09
+    }
+];
+```


### PR DESCRIPTION
@amychurchwell r?

This change allows the tests to use mock data, so we can remove the configuration from the worker when there are no tests active.