### PR TITLE
Moving the place we build the toml to the build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "pretest": "./node_modules/.bin/eslint .",
     "test": "mocha --timeout 20000",
-    "postinstall": "node bin/get_data.js"
+    "postbuild": "node bin/get_data.js"
   },
   "repository": {
     "type": "git",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,8 +4,6 @@ workers_dev = false
 
 [env.staging]
 name = "firefox-cro-redirector-stage"
-routes = [ "https://www.allizom.org/en-US/firefox/*" ]
 
 [env.prod]
 name = "firefox-cro-redirector-prod"
-routes = [ "https://www.mozilla.org/en-US/firefox/*" ]


### PR DESCRIPTION
Since the yarn/node artifacts are generated during the build step it makes sense to generate toml there as well.
We were orphaning the changes in the test step of the pipeline.
Also removing the paths from the toml to try and catch this sort of issue faster in the future.